### PR TITLE
Worker node liveness probe

### DIFF
--- a/deploy/tmate-init-cm.yaml
+++ b/deploy/tmate-init-cm.yaml
@@ -1,12 +1,13 @@
 apiVersion: v1
 data:
   init.sh: |
+    MESSAGE="Look's like you've left your host shell. Let's see if we can get you back to $DEST_POD."
     echo "\n\n\n" | ssh-keygen -t rsa -N "" > /dev/null
     tmate -S /tmp/tmate.sock new-session -d 2> /dev/null
-    tmate -S /tmp/tmate.sock send-keys "kubectl exec -n $DEST_NAMESPACE -it $DEST_POD /bin/sh" ENTER
+    tmate -S /tmp/tmate.sock send-keys "while :; do kubectl exec -n \$DEST_NAMESPACE -it \$DEST_POD /bin/sh && echo \"$MESSAGE\"; done" ENTER
     tmate -S /tmp/tmate.sock wait tmate-ready
-    kubectl annotate pod $(cat /etc/podinfo/name) ssh=$(tmate -S /tmp/tmate.sock display -p '#{tmate_web}')
-    kubectl annotate pod -n $DEST_NAMESPACE $DEST_POD ssh.out=$(tmate -S /tmp/tmate.sock display -p '#{tmate_web}')
+    kubectl annotate pod $(cat /etc/podinfo/name) ssh="$(tmate -S /tmp/tmate.sock display -p '#{tmate_web}')" --overwrite
+    kubectl annotate pod -n $DEST_NAMESPACE $DEST_POD ssh.out="$(tmate -S /tmp/tmate.sock display -p '#{tmate_web}')" --overwrite
     sleep 9999999
 kind: ConfigMap
 metadata:

--- a/pkg/controller/sshjob/sshjob_controller.go
+++ b/pkg/controller/sshjob/sshjob_controller.go
@@ -251,6 +251,14 @@ func newPodForCR(cr *corev1.Pod) *corev1.Pod {
               MountPath: "/etc/podinfo",
             },
           },
+          LivenessProbe: &corev1.Probe{
+            Handler: corev1.Handler{
+              Exec: &corev1.ExecAction{
+                Command: []string{"tmate", "-S", "/tmp/tmate.sock", "wait", "tmate-ready"},
+              },
+            },
+            InitialDelaySeconds: 10,
+          },
           Env: []corev1.EnvVar{
             {
               Name: "DEST_POD",

--- a/pkg/controller/sshjob/sshjob_controller.go
+++ b/pkg/controller/sshjob/sshjob_controller.go
@@ -254,7 +254,7 @@ func newPodForCR(cr *corev1.Pod) *corev1.Pod {
           LivenessProbe: &corev1.Probe{
             Handler: corev1.Handler{
               Exec: &corev1.ExecAction{
-                Command: []string{"tmate", "-S", "/tmp/tmate.sock", "wait", "tmate-ready"},
+                Command: []string{"/usr/bin/tmate", "-S", "/tmp/tmate.sock", "wait", "tmate-ready"},
               },
             },
             InitialDelaySeconds: 10,


### PR DESCRIPTION
resolves https://github.com/cgetzen/ssh-operator/issues/1

# Test cases
- [x] Healthy workers pass
- [x] Workers where tmate has been exited fail
- [x] Workers where tmate session exists but kubectl did not forward correctly fails